### PR TITLE
Refactor: Fix clipping of content in the Developer Support Card

### DIFF
--- a/app/src/main/java/com/lloir/ornaassistant/presentation/ui/components/DeveloperSupportCard.kt
+++ b/app/src/main/java/com/lloir/ornaassistant/presentation/ui/components/DeveloperSupportCard.kt
@@ -1,0 +1,80 @@
+package com.lloir.ornaassistant.presentation.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices.PIXEL_6_PRO
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.lloir.ornaassistant.presentation.theme.OrnaAssistantTheme
+
+@Composable
+fun DeveloperSupportCard(
+    modifier: Modifier = Modifier,
+    onDonateButtonClicked: () -> Unit
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = "Developed by lloir. If you wish, you can support the development by donating!",
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = onDonateButtonClicked,
+                contentPadding = ButtonDefaults.ButtonWithIconContentPadding
+            ) {
+                Icon(
+                    Icons.Default.Favorite,
+                    contentDescription = null,
+                    modifier = Modifier.size(ButtonDefaults.IconSize)
+                )
+                Spacer(modifier = Modifier.width(ButtonDefaults.IconSpacing))
+                Text("Donate via buymeacoffee")
+            }
+        }
+    }
+}
+
+
+@Preview(device = PIXEL_6_PRO)
+@Composable
+fun DeveloperSupportPreview() {
+    OrnaAssistantTheme {
+        DeveloperSupportCard(onDonateButtonClicked = {})
+    }
+}
+
+@Preview(device = PIXEL_6_PRO)
+@Composable
+fun DeveloperSupportPreviewWidth() {
+    OrnaAssistantTheme {
+        DeveloperSupportCard(modifier = Modifier.width(250.dp), onDonateButtonClicked = {})
+    }
+}

--- a/app/src/main/java/com/lloir/ornaassistant/presentation/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/lloir/ornaassistant/presentation/ui/main/MainScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.lloir.ornaassistant.presentation.ui.components.WeeklyChart
@@ -22,9 +21,9 @@ import com.lloir.ornaassistant.presentation.viewmodel.MainViewModel
 import com.lloir.ornaassistant.presentation.ui.components.AdaptiveContainer
 import com.lloir.ornaassistant.presentation.viewmodel.AccessibilityServiceViewModel
 import com.lloir.ornaassistant.presentation.viewmodel.ChartViewModel
-import com.lloir.ornaassistant.presentation.viewmodel.PermissionStatus
 import com.lloir.ornaassistant.utils.PermissionHelper
 import androidx.lifecycle.Lifecycle
+import com.lloir.ornaassistant.presentation.ui.components.DeveloperSupportCard
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -132,31 +131,8 @@ fun MainScreen(
             }
 
             // Developer Support Section
-            Card {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(
-                        text = "Developed by lloir. If you wish, you can support the development by donating!",
-                        style = MaterialTheme.typography.bodyMedium,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.padding(bottom = 16.dp)
-                    )
-
-                    Button(
-                        onClick = {
-                            uriHandler.openUri("https://buymeacoffee.com/lloir")
-                        },
-                        modifier = Modifier.size(width = 200.dp, height = 48.dp)
-                    ) {
-                        Icon(Icons.Default.Favorite, contentDescription = null)
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text("Donate via buymeacoffee")
-                    }
-                }
+            DeveloperSupportCard {
+                uriHandler.openUri("https://buymeacoffee.com/lloir")
             }
 
             // Error Handling


### PR DESCRIPTION
Extract the developer support content into a new composable function `DeveloperSupportCard`

This is what I was seeing on my device:
<img width="526" alt="Screenshot 2025-07-04 at 11 02 32 AM" src="https://github.com/user-attachments/assets/715c324f-9140-438a-a766-f50bc9b799d1" />

The button will wrap the content instead of having a hardcoded size.  A simple alternative would have been to just set the button width(250) instead of using size, but I chose to align with example in the button samples and in the NowInAndroid app.

The updated layout is based on the material3 library sample `ButtonWithIconSample`
<img width="524" alt="Screenshot 2025-07-04 at 11 54 34 AM" src="https://github.com/user-attachments/assets/453d6ff9-6bbe-4215-ac58-b2de974866a8" />
